### PR TITLE
fix(coserv): make CoservError thread-safe

### DIFF
--- a/src/error/coserv.rs
+++ b/src/error/coserv.rs
@@ -15,9 +15,9 @@ pub enum CoservError {
     #[error("Unknown signature algorithm {0}")]
     UnknownAlgorithm(i64),
     #[error("Error signing CoSERV: {0}")]
-    SigningError(Box<dyn std::error::Error + 'static>),
+    SigningError(Box<dyn std::error::Error + 'static + Send + Sync>),
     #[error("Error verifying CoSERV: {0}")]
-    VerificationError(Box<dyn std::error::Error + 'static>),
+    VerificationError(Box<dyn std::error::Error + 'static + Send + Sync>),
     #[error("CoSERV error: {0}")]
     Custom(String),
 }


### PR DESCRIPTION
Add Send + Sync bound on SigningError and VerificationError variants (introduced in 60966a4), so that CoservError becomes Send + Sync again. Fixes (https://github.com/veraison/coserv-rs/issues/12).